### PR TITLE
Snapshot line length

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -74,5 +74,9 @@ def write_snapshot(sql_parser: Parser, raw: str, file_path: Path):
         writer.write(raw)
         writer.write(f"\n\n{FILE_SEPARATOR}\n")
         writer.write(
-            black.format_str(str(sql_parser.get_tree(raw)), mode=black.FileMode())
+            black.format_str(
+                str(sql_parser.get_tree(raw)), mode=black.Mode(line_length=120)  # type: ignore # noqa: E501
+            )
         )
+        # The type: ignore is because mypy fails this line in python 3.6 for some
+        # reason.

--- a/tests/tree_snapshots/arg_item/010_arg_item_basic
+++ b/tests/tree_snapshots/arg_item/010_arg_item_basic
@@ -19,15 +19,7 @@ Tree(
                                     "function_expression",
                                     [
                                         Token("FUNCTION", "SUM"),
-                                        Tree(
-                                            "arg_list",
-                                            [
-                                                Tree(
-                                                    "arg_item",
-                                                    [Token("FIELD_NAME", "x")],
-                                                )
-                                            ],
-                                        ),
+                                        Tree("arg_list", [Tree("arg_item", [Token("FIELD_NAME", "x")])]),
                                     ],
                                 )
                             ],

--- a/tests/tree_snapshots/arg_item/020_arg_item_with_date_interval
+++ b/tests/tree_snapshots/arg_item/020_arg_item_with_date_interval
@@ -22,14 +22,8 @@ Tree(
                                         Tree(
                                             "arg_list",
                                             [
-                                                Tree(
-                                                    "arg_item",
-                                                    [Token("FIELD_NAME", "a")],
-                                                ),
-                                                Tree(
-                                                    "arg_item",
-                                                    [Token("DATE_INTERVAL", "month")],
-                                                ),
+                                                Tree("arg_item", [Token("FIELD_NAME", "a")]),
+                                                Tree("arg_item", [Token("DATE_INTERVAL", "month")]),
                                             ],
                                         ),
                                     ],

--- a/tests/tree_snapshots/arg_item/030_arg_item_with_time_interval
+++ b/tests/tree_snapshots/arg_item/030_arg_item_with_time_interval
@@ -22,14 +22,8 @@ Tree(
                                         Tree(
                                             "arg_list",
                                             [
-                                                Tree(
-                                                    "arg_item",
-                                                    [Token("FIELD_NAME", "b")],
-                                                ),
-                                                Tree(
-                                                    "arg_item",
-                                                    [Token("TIME_INTERVAL", "SECOND")],
-                                                ),
+                                                Tree("arg_item", [Token("FIELD_NAME", "b")]),
+                                                Tree("arg_item", [Token("TIME_INTERVAL", "SECOND")]),
                                             ],
                                         ),
                                     ],

--- a/tests/tree_snapshots/arg_item/040_arg_item_nested_func
+++ b/tests/tree_snapshots/arg_item/040_arg_item_nested_func
@@ -28,9 +28,7 @@ Tree(
                                                         Tree(
                                                             "function_expression",
                                                             [
-                                                                Token(
-                                                                    "FUNCTION", "date"
-                                                                ),
+                                                                Token("FUNCTION", "date"),
                                                                 Tree(
                                                                     "arg_list",
                                                                     [
@@ -68,10 +66,7 @@ Tree(
                                                         )
                                                     ],
                                                 ),
-                                                Tree(
-                                                    "arg_item",
-                                                    [Token("DATE_INTERVAL", "month")],
-                                                ),
+                                                Tree("arg_item", [Token("DATE_INTERVAL", "month")]),
                                             ],
                                         ),
                                     ],

--- a/tests/tree_snapshots/from_item/010_single_table
+++ b/tests/tree_snapshots/from_item/010_single_table
@@ -9,15 +9,9 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list",
-                    [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])],
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])]),
                 Token("FROM", "from"),
-                Tree(
-                    "from_clause",
-                    [Tree("simple_table_name", [Token("CNAME", "table")])],
-                ),
+                Tree("from_clause", [Tree("simple_table_name", [Token("CNAME", "table")])]),
             ],
         )
     ],

--- a/tests/tree_snapshots/from_item/020_single_table_outerbackticks
+++ b/tests/tree_snapshots/from_item/020_single_table_outerbackticks
@@ -9,10 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list",
-                    [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])],
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",

--- a/tests/tree_snapshots/from_item/030_single_table_multiplebackticks
+++ b/tests/tree_snapshots/from_item/030_single_table_multiplebackticks
@@ -9,10 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list",
-                    [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])],
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",

--- a/tests/tree_snapshots/from_item/100_sub_query
+++ b/tests/tree_snapshots/from_item/100_sub_query
@@ -9,10 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list",
-                    [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])],
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",
@@ -23,33 +20,16 @@ Tree(
                                 Tree(
                                     "query_expr",
                                     [
-                                        Tree(
-                                            "select_statement",
-                                            [Token("SELECT", "select")],
-                                        ),
+                                        Tree("select_statement", [Token("SELECT", "select")]),
                                         Tree(
                                             "select_list",
                                             [
-                                                Tree(
-                                                    "select_item_unaliased",
-                                                    [Token("FIELD_NAME", "field")],
-                                                ),
-                                                Tree(
-                                                    "select_item_unaliased",
-                                                    [Token("FIELD_NAME", "field2")],
-                                                ),
+                                                Tree("select_item_unaliased", [Token("FIELD_NAME", "field")]),
+                                                Tree("select_item_unaliased", [Token("FIELD_NAME", "field2")]),
                                             ],
                                         ),
                                         Token("FROM", "from"),
-                                        Tree(
-                                            "from_clause",
-                                            [
-                                                Tree(
-                                                    "simple_table_name",
-                                                    [Token("CNAME", "table")],
-                                                )
-                                            ],
-                                        ),
+                                        Tree("from_clause", [Tree("simple_table_name", [Token("CNAME", "table")])]),
                                     ],
                                 )
                             ],

--- a/tests/tree_snapshots/join_operation/010_default_inner_join
+++ b/tests/tree_snapshots/join_operation/010_default_inner_join
@@ -9,9 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",

--- a/tests/tree_snapshots/join_operation/020_inner_join
+++ b/tests/tree_snapshots/join_operation/020_inner_join
@@ -9,9 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",

--- a/tests/tree_snapshots/join_operation/030_left_join
+++ b/tests/tree_snapshots/join_operation/030_left_join
@@ -9,9 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",

--- a/tests/tree_snapshots/join_operation/040_right_join
+++ b/tests/tree_snapshots/join_operation/040_right_join
@@ -9,9 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",

--- a/tests/tree_snapshots/join_operation/050_full_join
+++ b/tests/tree_snapshots/join_operation/050_full_join
@@ -9,9 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",

--- a/tests/tree_snapshots/select_item/010_select_star
+++ b/tests/tree_snapshots/select_item/010_select_star
@@ -9,14 +9,9 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("STAR", "*")])]),
                 Token("FROM", "from"),
-                Tree(
-                    "from_clause",
-                    [Tree("simple_table_name", [Token("CNAME", "table")])],
-                ),
+                Tree("from_clause", [Tree("simple_table_name", [Token("CNAME", "table")])]),
             ],
         )
     ],

--- a/tests/tree_snapshots/select_item/020_select_item_no_alias
+++ b/tests/tree_snapshots/select_item/020_select_item_no_alias
@@ -9,15 +9,9 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list",
-                    [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])],
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])]),
                 Token("FROM", "from"),
-                Tree(
-                    "from_clause",
-                    [Tree("simple_table_name", [Token("CNAME", "table")])],
-                ),
+                Tree("from_clause", [Tree("simple_table_name", [Token("CNAME", "table")])]),
             ],
         )
     ],

--- a/tests/tree_snapshots/select_item/030_select_item_implicit_alias
+++ b/tests/tree_snapshots/select_item/030_select_item_implicit_alias
@@ -13,19 +13,12 @@ Tree(
                     "select_list",
                     [
                         Tree(
-                            "select_item_aliased",
-                            [
-                                Token("FIELD_NAME", "field"),
-                                Token("ALIAS_NAME", "new_field_name"),
-                            ],
+                            "select_item_aliased", [Token("FIELD_NAME", "field"), Token("ALIAS_NAME", "new_field_name")]
                         )
                     ],
                 ),
                 Token("FROM", "from"),
-                Tree(
-                    "from_clause",
-                    [Tree("simple_table_name", [Token("CNAME", "table")])],
-                ),
+                Tree("from_clause", [Tree("simple_table_name", [Token("CNAME", "table")])]),
             ],
         )
     ],

--- a/tests/tree_snapshots/select_item/040_select_item_explicit_alias
+++ b/tests/tree_snapshots/select_item/040_select_item_explicit_alias
@@ -13,19 +13,12 @@ Tree(
                     "select_list",
                     [
                         Tree(
-                            "select_item_aliased",
-                            [
-                                Token("FIELD_NAME", "field"),
-                                Token("ALIAS_NAME", "new_field_name"),
-                            ],
+                            "select_item_aliased", [Token("FIELD_NAME", "field"), Token("ALIAS_NAME", "new_field_name")]
                         )
                     ],
                 ),
                 Token("FROM", "from"),
-                Tree(
-                    "from_clause",
-                    [Tree("simple_table_name", [Token("CNAME", "table")])],
-                ),
+                Tree("from_clause", [Tree("simple_table_name", [Token("CNAME", "table")])]),
             ],
         )
     ],

--- a/tests/tree_snapshots/where_clause/010_single_expression
+++ b/tests/tree_snapshots/where_clause/010_single_expression
@@ -9,10 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list",
-                    [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])],
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",
@@ -22,15 +19,7 @@ Tree(
                             "from_modifier",
                             [
                                 Token("WHERE", "where"),
-                                Tree(
-                                    "where_list",
-                                    [
-                                        Tree(
-                                            "first_where_item",
-                                            [Token("FIELD_NAME", "a")],
-                                        )
-                                    ],
-                                ),
+                                Tree("where_list", [Tree("first_where_item", [Token("FIELD_NAME", "a")])]),
                             ],
                         ),
                     ],

--- a/tests/tree_snapshots/where_clause/100_leading_unary_bool_operator
+++ b/tests/tree_snapshots/where_clause/100_leading_unary_bool_operator
@@ -9,10 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list",
-                    [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])],
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",
@@ -31,10 +28,7 @@ Tree(
                                                 Tree(
                                                     "leading_unary_bool_operation",
                                                     [
-                                                        Token(
-                                                            "LEADING_UNARY_BOOL_OPERATOR",
-                                                            "NOT",
-                                                        ),
+                                                        Token("LEADING_UNARY_BOOL_OPERATOR", "NOT"),
                                                         Token("FIELD_NAME", "a"),
                                                     ],
                                                 )

--- a/tests/tree_snapshots/where_clause/110_trailing_unary_bool_operator
+++ b/tests/tree_snapshots/where_clause/110_trailing_unary_bool_operator
@@ -9,10 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list",
-                    [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])],
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",

--- a/tests/tree_snapshots/where_clause/200_binary_bool_expression
+++ b/tests/tree_snapshots/where_clause/200_binary_bool_expression
@@ -9,10 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list",
-                    [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])],
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",
@@ -25,16 +22,10 @@ Tree(
                                 Tree(
                                     "where_list",
                                     [
-                                        Tree(
-                                            "first_where_item",
-                                            [Token("FIELD_NAME", "a")],
-                                        ),
+                                        Tree("first_where_item", [Token("FIELD_NAME", "a")]),
                                         Tree(
                                             "after_where_item",
-                                            [
-                                                Token("BINARY_BOOL_OPERATOR", "AND"),
-                                                Token("FIELD_NAME", "b"),
-                                            ],
+                                            [Token("BINARY_BOOL_OPERATOR", "AND"), Token("FIELD_NAME", "b")],
                                         ),
                                     ],
                                 ),

--- a/tests/tree_snapshots/where_clause/210_multiple_binary_bool_expression
+++ b/tests/tree_snapshots/where_clause/210_multiple_binary_bool_expression
@@ -9,10 +9,7 @@ Tree(
             "query_expr",
             [
                 Tree("select_statement", [Token("SELECT", "select")]),
-                Tree(
-                    "select_list",
-                    [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])],
-                ),
+                Tree("select_list", [Tree("select_item_unaliased", [Token("FIELD_NAME", "field")])]),
                 Token("FROM", "from"),
                 Tree(
                     "from_clause",
@@ -25,23 +22,14 @@ Tree(
                                 Tree(
                                     "where_list",
                                     [
+                                        Tree("first_where_item", [Token("FIELD_NAME", "a")]),
                                         Tree(
-                                            "first_where_item",
-                                            [Token("FIELD_NAME", "a")],
+                                            "after_where_item",
+                                            [Token("BINARY_BOOL_OPERATOR", "or"), Token("FIELD_NAME", "b")],
                                         ),
                                         Tree(
                                             "after_where_item",
-                                            [
-                                                Token("BINARY_BOOL_OPERATOR", "or"),
-                                                Token("FIELD_NAME", "b"),
-                                            ],
-                                        ),
-                                        Tree(
-                                            "after_where_item",
-                                            [
-                                                Token("BINARY_BOOL_OPERATOR", "and"),
-                                                Token("FIELD_NAME", "c"),
-                                            ],
+                                            [Token("BINARY_BOOL_OPERATOR", "and"), Token("FIELD_NAME", "c")],
                                         ),
                                     ],
                                 ),


### PR DESCRIPTION
* change tree parsing to have a line length of 120 instead of 88 so that
  there aren't so many line breaks in deeply nested trees