### PR TITLE
Table reference fields

### DIFF
--- a/sqlean/grammar/expression.lark
+++ b/sqlean/grammar/expression.lark
@@ -15,7 +15,12 @@ ALIAS_NAME: CNAME
     | bool_expression
 
 ?base_expression: FIELD_NAME
+    | table_referenced_field
     | function_expression
+
+FIELD_NAME: CNAME
+table_referenced_field: table_name "." FIELD_NAME
+function_expression: FUNCTION "(" arg_list ")"
 
 ?bool_expression: base_expression
     | unary_bool_operation
@@ -28,9 +33,6 @@ first_bool_item: bool_item
 after_bool_item: BINARY_BOOL_OPERATOR bool_item
 !?bool_item: "(" (bool_expression | binary_bool_operation) ")"
     | bool_expression
-
-FIELD_NAME: CNAME
-function_expression: FUNCTION "(" arg_list ")"
 
 arg_list: arg_item ("," arg_item)*
 
@@ -80,3 +82,4 @@ TRUE: "TRUE"i
 FALSE: "FALSE"i
 
 %import common.CNAME
+%import table.table_name

--- a/sqlean/grammar/sql.lark
+++ b/sqlean/grammar/sql.lark
@@ -24,17 +24,6 @@ groupby_item: base_expression | INT
 orderby_list: orderby_item ("," orderby_item)*
 !orderby_item: (base_expression | INT) ["ASC"i | "DESC"i]
 
-?table_name: simple_table_name
-    | explicit_table_name
-
-simple_table_name: CNAME
-explicit_table_name: "`" PROJECT_ID  "." DATASET_ID "." TABLE_ID "`"
-    | "`" PROJECT_ID  "`.`" DATASET_ID "`.`" TABLE_ID "`"
-
-PROJECT_ID: CNAME
-DATASET_ID: CNAME
-TABLE_ID: CNAME
-
 ?join_operation: cross_join_operation
     | join_operation_with_condition
 
@@ -63,6 +52,7 @@ using_list: FIELD_NAME ("," FIELD_NAME)*
 %import expression.bool_list
 %import expression.base_expression
 %import expression.FIELD_NAME
+%import table.table_name
 // %import expression.as_alias
 %import common.WS
 %import common.CNAME

--- a/sqlean/grammar/table.lark
+++ b/sqlean/grammar/table.lark
@@ -1,0 +1,13 @@
+?table_name: simple_table_name
+    | explicit_table_name
+
+simple_table_name: CNAME
+
+?explicit_table_name: "`" PROJECT_ID  "." DATASET_ID "." TABLE_ID "`"
+	| "`" PROJECT_ID  "`.`" DATASET_ID "`.`" TABLE_ID "`"
+
+PROJECT_ID: CNAME
+DATASET_ID: CNAME
+TABLE_ID: CNAME
+
+%import common.CNAME

--- a/sqlean/style_mixins.py
+++ b/sqlean/style_mixins.py
@@ -22,7 +22,10 @@ class CraftMixin(Transformer):  # type: ignore
         return self.__indent
 
     def _simple_indent(self, node: CTree) -> str:
-        return self._apply_indent(self._rollup_space(node), node.data.indent_level)
+        """Apply indentation to a node, left strips previous indentation"""
+        return self._apply_indent(
+            self._rollup_space(node).lstrip(), node.data.indent_level
+        )
 
     def _apply_indent(self, text: str, indent_level: int) -> str:
         """Apply indentation to text"""
@@ -43,6 +46,10 @@ class CraftMixin(Transformer):  # type: ignore
     def _rollup_space(self, node: CTree) -> str:
         """Join list with space"""
         return " ".join(self._stringify_children(node))
+
+    def _rollup_dot(self, node: CTree) -> str:
+        """Join list with space"""
+        return ".".join(self._stringify_children(node))
 
     def _rollup_comma_inline(self, node: CTree) -> str:
         """Join list with comma space"""
@@ -87,6 +94,10 @@ class SelectMixin(CraftMixin):
         output = f"{node.children[0]} AS {node.children[1]}"
         return self._apply_indent(output, node.data.indent_level)
 
+    def table_referenced_field(self, node: CTree) -> str:
+        """print table_referenced_field"""
+        return self._rollup_dot(node)
+
 
 @v_args(tree=True)
 class FromMixin(CraftMixin):
@@ -106,7 +117,7 @@ class FromMixin(CraftMixin):
 
     def explicit_table_name(self, node: CTree) -> str:
         """print explicit_table_name"""
-        output = f"`{node.children[0]}.{node.children[1]}.{node.children[2]}`"
+        output = f"`{self._rollup_dot(node)}`"
         return self._apply_indent(output, node.data.indent_level)
 
 

--- a/tests/snapshots/select_item/100_simple_table_ref
+++ b/tests/snapshots/select_item/100_simple_table_ref
@@ -1,0 +1,41 @@
+select table.field from table
+
+---
+
+SELECT
+    table.field,
+FROM
+    table
+
+---
+
+Tree(
+    "query_file",
+    [
+        Tree(
+            "query_expr",
+            [
+                Tree("select_statement", [Token("SELECT", "select")]),
+                Tree(
+                    "select_list",
+                    [
+                        Tree(
+                            "select_item_unaliased",
+                            [
+                                Tree(
+                                    "table_referenced_field",
+                                    [
+                                        Tree("simple_table_name", [Token("CNAME", "table")]),
+                                        Token("FIELD_NAME", "field"),
+                                    ],
+                                )
+                            ],
+                        )
+                    ],
+                ),
+                Token("FROM", "from"),
+                Tree("from_clause", [Tree("simple_table_name", [Token("CNAME", "table")])]),
+            ],
+        )
+    ],
+)

--- a/tests/snapshots/select_item/110_explicit_table_ref
+++ b/tests/snapshots/select_item/110_explicit_table_ref
@@ -1,0 +1,56 @@
+select `a.b.c`.field from `a.b.c`
+
+---
+
+SELECT
+    `a.b.c`.field,
+FROM
+    `a.b.c`
+
+---
+
+Tree(
+    "query_file",
+    [
+        Tree(
+            "query_expr",
+            [
+                Tree("select_statement", [Token("SELECT", "select")]),
+                Tree(
+                    "select_list",
+                    [
+                        Tree(
+                            "select_item_unaliased",
+                            [
+                                Tree(
+                                    "table_referenced_field",
+                                    [
+                                        Tree(
+                                            "explicit_table_name",
+                                            [
+                                                Token("PROJECT_ID", "a"),
+                                                Token("DATASET_ID", "b"),
+                                                Token("TABLE_ID", "c"),
+                                            ],
+                                        ),
+                                        Token("FIELD_NAME", "field"),
+                                    ],
+                                )
+                            ],
+                        )
+                    ],
+                ),
+                Token("FROM", "from"),
+                Tree(
+                    "from_clause",
+                    [
+                        Tree(
+                            "explicit_table_name",
+                            [Token("PROJECT_ID", "a"), Token("DATASET_ID", "b"), Token("TABLE_ID", "c")],
+                        )
+                    ],
+                ),
+            ],
+        )
+    ],
+)

--- a/tests/snapshots/select_item/120_explicit_wrong_table_ref
+++ b/tests/snapshots/select_item/120_explicit_wrong_table_ref
@@ -1,0 +1,56 @@
+select `a`.`b`.`c`.field from `a`.`b`.`c`
+
+---
+
+SELECT
+    `a.b.c`.field,
+FROM
+    `a.b.c`
+
+---
+
+Tree(
+    "query_file",
+    [
+        Tree(
+            "query_expr",
+            [
+                Tree("select_statement", [Token("SELECT", "select")]),
+                Tree(
+                    "select_list",
+                    [
+                        Tree(
+                            "select_item_unaliased",
+                            [
+                                Tree(
+                                    "table_referenced_field",
+                                    [
+                                        Tree(
+                                            "explicit_table_name",
+                                            [
+                                                Token("PROJECT_ID", "a"),
+                                                Token("DATASET_ID", "b"),
+                                                Token("TABLE_ID", "c"),
+                                            ],
+                                        ),
+                                        Token("FIELD_NAME", "field"),
+                                    ],
+                                )
+                            ],
+                        )
+                    ],
+                ),
+                Token("FROM", "from"),
+                Tree(
+                    "from_clause",
+                    [
+                        Tree(
+                            "explicit_table_name",
+                            [Token("PROJECT_ID", "a"), Token("DATASET_ID", "b"), Token("TABLE_ID", "c")],
+                        )
+                    ],
+                ),
+            ],
+        )
+    ],
+)


### PR DESCRIPTION
* allow table.field or `project.dataset.table`.field as expressions
* improve DX for snapshots:
  * write out the tree even if styling fails
  * write out the styling exception in the snapshot