### PR TITLE
Between operator

### DIFF
--- a/sqlean/grammar/expression.lark
+++ b/sqlean/grammar/expression.lark
@@ -1,17 +1,49 @@
 select_list: select_item ("," [INLINE_COMMENT] select_item)* [","] [INLINE_COMMENT]
 ?select_item: select_item_unaliased
     | select_item_aliased
-select_item_aliased: expression as_alias
-!select_item_unaliased: expression
+select_item_aliased: base_expression as_alias
+!select_item_unaliased: base_expression
     | "*"
 
 ?base_expression: table_referenced_field
     | standard_function_expression
     | window_function_expression
+    | case_expression
     | MACRO
     | CNAME
     | constant
 
+table_referenced_field: CNAME "." CNAME
+    | explicit_table_name "." CNAME
+
+///////////////
+// functions //
+///////////////
+standard_function_expression: function_name "(" arg_list ")"
+window_function_expression: function_name "(" [arg_list] ")" "OVER"i over_clause
+!function_name: CNAME
+    | ["`" PROJECT_ID  "`."] CNAME "." CNAME
+
+over_clause: "(" window_specification  ")" // or named_window
+window_specification: [partition_modifier] [window_orderby_modifier] // [window_frame_clause] TODO
+partition_modifier: PARTITION_BY field_list
+PARTITION_BY: "PARTITION"i WS "BY"i
+window_orderby_modifier: ORDER_BY orderby_list
+
+!orderby_modifier: ORDER_BY orderby_list
+ORDER_BY.2: "ORDER"i WS "BY"i
+orderby_list: orderby_item ("," orderby_item)*
+!orderby_item: base_expression ["ASC"i | "DESC"i]
+
+arg_list: arg_item ("," arg_item)*
+!arg_item: interval
+    | base_expression
+    | base_expression "AS"i data_type
+    | interval "FROM"i base_expression
+
+///////////////
+// constants //
+///////////////
 ?constant: SIGNED_NUMBER
     | string
     | NULL
@@ -25,82 +57,59 @@ SINGLE_QUOTED_STRING: "'" _STRING_ESC_INNER "'"
 ?boolean: TRUE
     | FALSE
 
-table_referenced_field: CNAME "." CNAME
-    | explicit_table_name "." CNAME
+NULL: "NULL"i
+TRUE: "TRUE"i
+FALSE: "FALSE"i
 
-standard_function_expression: function_name "(" arg_list ")"
-window_function_expression: function_name "(" [arg_list] ")" "OVER"i over_clause
-!function_name: CNAME
-    | ["`" PROJECT_ID  "`."] CNAME "." CNAME
-
-over_clause: "(" window_specification  ")" // or named_window
-window_specification: [partition_modifier] [window_orderby_modifier] // [window_frame_clause] TODO
-partition_modifier: PARTITION_BY field_list
-PARTITION_BY: "PARTITION"i WS "BY"i
-window_orderby_modifier: ORDER_BY orderby_list
-
+//////////
+// case //
+//////////
 ?case_expression: common_case_expression
     | separate_case_expression
 !common_case_expression: "CASE"i base_expression when_list [else_clause] "END"i
 !separate_case_expression: "CASE"i when_list [else_clause] "END"i
 when_list: when_item+
-!when_item: "WHEN"i expression "THEN"i base_expression
+!when_item: "WHEN"i bool_expression "THEN"i base_expression
 !else_clause: "ELSE"i base_expression
 
-indented_expression: expression
-!?expression: base_expression
+/////////////////////
+// bool_expression //
+/////////////////////
+indented_bool_expression: bool_expression
+!?bool_expression: binary_bool_operation
+    | comparison_expression
+    | "(" bool_expression ")" -> parenthetical_bool_expression
     | unary_bool_operation
-    | binary_bool_operation
-    | binary_comparison_operation
-    | like_comparison_operation
-    | in_comparison_operation
-    | "(" expression ")" -> parenthetical_expression
-    | case_expression
-binary_bool_operation: expression BINARY_BOOL_OPERATOR expression
+    | base_expression
 
-arg_list: arg_item ("," arg_item)*
-!arg_item: interval
-    | expression
-    | expression "AS"i data_type
-    | interval "FROM"i expression
-!data_type: "BOOL"i
-    | "BYTES"i ["(" INT ")"]
-    | "DATE"i
-    | "DATETIME"i
-    | "INT64"i
-    | "INT"i
-    | "SMALLINT"i
-    | "INTEGER"i
-    | "BIGINT"i
-    | "TINYINT"i
-    | "BYTEINT"i
-    | "NUMERIC"i
-    | "DECIMAL"i
-    | "BIGNUMERIC"i
-    | "BIGDECIMAL"i
-    | "FLOAT64"i
-    | "STRING"i
-?interval: DATE_INTERVAL
-    | TIME_INTERVAL
-DATE_INTERVAL.2: "DAY"i
-    | "DAYOFYEAR"i
-    | "MONTH"i
-    | "WEEK"i
-    | "ISOWEEK"i
-    | "YEAR"i
-    | "ISOYEAR"i
-TIME_INTERVAL.2: "MICROSECOND"i
-    | "MILLISECOND"i
-    | "SECOND"i
-    | "MINUTE"i
-    | "HOUR"i
-
-binary_comparison_operation: base_expression BINARY_COMPARISON_OPERATOR base_expression
-BINARY_BOOL_OPERATOR.2: AND
-    | OR
+binary_bool_operation: bool_expression AND bool_expression
+    | bool_expression OR bool_expression
 AND: "AND"i
 OR: "OR"i
 
+//////////////////////////
+// unary_bool_operation //
+//////////////////////////
+?unary_bool_operation: leading_unary_bool_operation
+    | trailing_unary_bool_operation
+leading_unary_bool_operation: LEADING_UNARY_BOOL_OPERATOR base_expression
+trailing_unary_bool_operation: base_expression trailing_unary_bool_operator
+LEADING_UNARY_BOOL_OPERATOR: NOT
+trailing_unary_bool_operator: IS [NOT] NULL
+    | IS [NOT] TRUE
+    | IS [NOT] FALSE
+NOT: "NOT"i
+IS: "IS"i
+
+///////////////////////////
+// comparison_expression //
+///////////////////////////
+?comparison_expression: binary_comparison_operation
+    | like_comparison_operation
+    | in_comparison_operation
+    | between_comparison_operation
+
+binary_comparison_operation: base_expression BINARY_COMPARISON_OPERATOR base_expression
 BINARY_COMPARISON_OPERATOR: "="
     | ">"
     | ">="
@@ -117,40 +126,27 @@ in_comparison_operation: base_expression [NOT] IN in_list
 IN: "IN"i
 in_list: "(" constant ("," constant)* ")"
 
-?unary_bool_operation: leading_unary_bool_operation
-    | trailing_unary_bool_operation
-leading_unary_bool_operation: LEADING_UNARY_BOOL_OPERATOR base_expression
-trailing_unary_bool_operation: base_expression trailing_unary_bool_operator
-LEADING_UNARY_BOOL_OPERATOR: NOT
-trailing_unary_bool_operator: IS [NOT] NULL
-    | IS [NOT] TRUE
-    | IS [NOT] FALSE
-NOT: "NOT"i
-IS: "IS"i
-NULL: "NULL"i
-TRUE: "TRUE"i
-FALSE: "FALSE"i
+between_comparison_operation: base_expression [NOT] BETWEEN base_expression AND base_expression
+BETWEEN.2: "BETWEEN"i
+
 
 field_list: base_expression ("," base_expression)*
 
 !groupby_modifier: GROUP_BY field_list [having_clause]
 GROUP_BY.2: "GROUP"i WS "BY"i
 
-!having_clause: "HAVING"i indented_expression
+!having_clause: "HAVING"i indented_bool_expression
 
-!orderby_modifier: ORDER_BY orderby_list
-ORDER_BY.2: "ORDER"i WS "BY"i
-orderby_list: orderby_item ("," orderby_item)*
-!orderby_item: base_expression ["ASC"i | "DESC"i]
 
 %import common.CNAME
-%import common.INT
 %import common.SIGNED_NUMBER
 %import common._STRING_ESC_INNER
+%import common.WS
 %import alias.as_alias
 %import comment.INLINE_COMMENT
+%import jinja.MACRO
+%import reserved_words.data_type
+%import reserved_words.interval
 %import table.explicit_table_name
 %import table.PROJECT_ID
 %import table.DATASET_ID
-%import common.WS
-%import jinja.MACRO

--- a/sqlean/grammar/reserved_words.lark
+++ b/sqlean/grammar/reserved_words.lark
@@ -1,0 +1,33 @@
+!data_type: "BOOL"i
+    | "BYTES"i ["(" INT ")"]
+    | "DATE"i
+    | "DATETIME"i
+    | "INT64"i
+    | "INT"i
+    | "SMALLINT"i
+    | "INTEGER"i
+    | "BIGINT"i
+    | "TINYINT"i
+    | "BYTEINT"i
+    | "NUMERIC"i
+    | "DECIMAL"i
+    | "BIGNUMERIC"i
+    | "BIGDECIMAL"i
+    | "FLOAT64"i
+    | "STRING"i
+?interval: DATE_INTERVAL
+    | TIME_INTERVAL
+DATE_INTERVAL.2: "DAY"i
+    | "DAYOFYEAR"i
+    | "MONTH"i
+    | "WEEK"i
+    | "ISOWEEK"i
+    | "YEAR"i
+    | "ISOYEAR"i
+TIME_INTERVAL.2: "MICROSECOND"i
+    | "MILLISECOND"i
+    | "SECOND"i
+    | "MINUTE"i
+    | "HOUR"i
+
+%import common.INT

--- a/sqlean/grammar/sql.lark
+++ b/sqlean/grammar/sql.lark
@@ -11,7 +11,7 @@ query_file: [CONFIG] query_expr
 !select_expr: select_type select_list ["FROM"i from_clause] [limit_clause]
 
 !select_type: "SELECT"i
-!from_clause: from_item ["WHERE"i indented_expression] [groupby_modifier] [orderby_modifier]
+!from_clause: from_item ["WHERE"i indented_bool_expression] [groupby_modifier] [orderby_modifier]
 
 !?from_item: join_operation
     | table_item
@@ -37,14 +37,14 @@ full_join: "FULL"i ["OUTER"i] "JOIN"i
 left_join: "LEFT"i ["OUTER"i] "JOIN"i
 right_join: "RIGHT"i ["OUTER"i] "JOIN"i
 
-!on_clause: "ON"i indented_expression
+!on_clause: "ON"i indented_bool_expression
 !using_clause: "USING"i "(" using_list ")"
 using_list: CNAME ("," CNAME)*
 
 !limit_clause: "LIMIT"i INT ["OFFSET"i INT]
 
 
-%import expression.indented_expression
+%import expression.indented_bool_expression
 %import expression.groupby_modifier
 %import expression.orderby_modifier
 %import expression.select_list

--- a/sqlean/sql_styler.py
+++ b/sqlean/sql_styler.py
@@ -466,16 +466,15 @@ class ExpressionMixin(BaseMixin):
         return f"{node.children[0]}\n{node.children[1]} {node.children[2]}"
 
     @staticmethod
-    def parenthetical_expression(node: CTree) -> str:
-        """print parenthetical_expression"""
-        # remove line separators when parenthesized.
+    def parenthetical_bool_expression(node: CTree) -> str:
+        """print parenthetical_bool_expression, removes line separators when
+        parenthesized"""
         # TODO: Deal with long lines
-        if isinstance(node.children[1], str):
-            output = str(node.children[1]).replace(linesep, " ")
+        output = str(node.children[1]).replace(linesep, " ")
         return f"({output})"
 
-    def indented_expression(self, node: CTree) -> str:
-        """rollup indented_expression"""
+    def indented_bool_expression(self, node: CTree) -> str:
+        """rollup indented_bool_expression"""
         return self._simple_indent(node)
 
 
@@ -498,6 +497,10 @@ class ComparisonMixin(BaseMixin):
     def in_list(self, node: CTree) -> str:
         """rollup in_list"""
         return f"({self._rollup_comma_inline(node)})"
+
+    def between_comparison_operation(self, node: CTree) -> str:
+        """rollup between_comparison_operation"""
+        return self._rollup_space(node)
 
 
 @v_args(tree=True)

--- a/tests/snapshots/case_statement/100_separate_when_only.snapshot
+++ b/tests/snapshots/case_statement/100_separate_when_only.snapshot
@@ -91,7 +91,7 @@ Tree(
                                                                         Token("CNAME", "d"),
                                                                     ],
                                                                 ),
-                                                                Token("BINARY_BOOL_OPERATOR", "AND"),
+                                                                Token("AND", "AND"),
                                                                 Tree(
                                                                     "binary_comparison_operation",
                                                                     [

--- a/tests/snapshots/case_statement/110_separate_with_else.snapshot
+++ b/tests/snapshots/case_statement/110_separate_with_else.snapshot
@@ -62,7 +62,7 @@ Tree(
                                                                         Token("CNAME", "c"),
                                                                     ],
                                                                 ),
-                                                                Token("BINARY_BOOL_OPERATOR", "OR"),
+                                                                Token("OR", "OR"),
                                                                 Tree(
                                                                     "binary_comparison_operation",
                                                                     [

--- a/tests/snapshots/case_statement/120_separate_with_else_nested.snapshot
+++ b/tests/snapshots/case_statement/120_separate_with_else_nested.snapshot
@@ -89,7 +89,7 @@ Tree(
                                                                                         Token("CNAME", "c"),
                                                                                     ],
                                                                                 ),
-                                                                                Token("BINARY_BOOL_OPERATOR", "OR"),
+                                                                                Token("OR", "OR"),
                                                                                 Tree(
                                                                                     "binary_comparison_operation",
                                                                                     [

--- a/tests/snapshots/composite/000_standard_sql.snapshot
+++ b/tests/snapshots/composite/000_standard_sql.snapshot
@@ -327,7 +327,7 @@ Tree(
                                                                                 ),
                                                                                 Token("WHERE", "where"),
                                                                                 Tree(
-                                                                                    "indented_expression",
+                                                                                    "indented_bool_expression",
                                                                                     [
                                                                                         Tree(
                                                                                             "binary_comparison_operation",
@@ -553,7 +553,7 @@ Tree(
                                                             [
                                                                 Token("ON", "on"),
                                                                 Tree(
-                                                                    "indented_expression",
+                                                                    "indented_bool_expression",
                                                                     [
                                                                         Tree(
                                                                             "binary_comparison_operation",
@@ -620,7 +620,7 @@ Tree(
                                 ),
                                 Token("WHERE", "where"),
                                 Tree(
-                                    "indented_expression",
+                                    "indented_bool_expression",
                                     [
                                         Tree(
                                             "binary_comparison_operation",

--- a/tests/snapshots/composite/100_dbt.snapshot
+++ b/tests/snapshots/composite/100_dbt.snapshot
@@ -97,13 +97,13 @@ Tree(
                         ),
                         Token("WHERE", "WHERE"),
                         Tree(
-                            "indented_expression",
+                            "indented_bool_expression",
                             [
                                 Tree(
                                     "binary_bool_operation",
                                     [
                                         Token("MACRO", "{{ macro_3('arg1', 'arg2') }}"),
-                                        Token("BINARY_BOOL_OPERATOR", "AND"),
+                                        Token("AND", "AND"),
                                         Token("CNAME", "b"),
                                     ],
                                 )

--- a/tests/snapshots/function/100_cast_arguments.snapshot
+++ b/tests/snapshots/function/100_cast_arguments.snapshot
@@ -50,7 +50,7 @@ Tree(
                                                     [
                                                         Token("CNAME", "a"),
                                                         Token("AS", "as"),
-                                                        Tree("data_type", [Token("ANON_2", "int")]),
+                                                        Tree("data_type", [Token("ANON_0", "int")]),
                                                     ],
                                                 )
                                             ],

--- a/tests/snapshots/function/200_nonstandard_function_names.snapshot
+++ b/tests/snapshots/function/200_nonstandard_function_names.snapshot
@@ -85,7 +85,7 @@ Tree(
                                             [
                                                 Token("BACKQUOTE", "`"),
                                                 Token("PROJECT_ID", "project_id"),
-                                                Token("ANON_1", "`."),
+                                                Token("ANON_2", "`."),
                                                 Token("CNAME", "dataset_id"),
                                                 Token("DOT", "."),
                                                 Token("CNAME", "function"),

--- a/tests/snapshots/group_by/100_having_basic.snapshot
+++ b/tests/snapshots/group_by/100_having_basic.snapshot
@@ -63,7 +63,7 @@ Tree(
                                     [
                                         Token("HAVING", "having"),
                                         Tree(
-                                            "indented_expression",
+                                            "indented_bool_expression",
                                             [
                                                 Tree(
                                                     "binary_comparison_operation",

--- a/tests/snapshots/group_by/110_having_nested.snapshot
+++ b/tests/snapshots/group_by/110_having_nested.snapshot
@@ -90,7 +90,7 @@ Tree(
                                                     [
                                                         Token("HAVING", "having"),
                                                         Tree(
-                                                            "indented_expression",
+                                                            "indented_bool_expression",
                                                             [
                                                                 Tree(
                                                                     "binary_comparison_operation",

--- a/tests/snapshots/group_by/120_having_multiple.snapshot
+++ b/tests/snapshots/group_by/120_having_multiple.snapshot
@@ -64,7 +64,7 @@ Tree(
                                     [
                                         Token("HAVING", "having"),
                                         Tree(
-                                            "indented_expression",
+                                            "indented_bool_expression",
                                             [
                                                 Tree(
                                                     "binary_bool_operation",
@@ -88,7 +88,7 @@ Tree(
                                                                 Token("SIGNED_NUMBER", "1"),
                                                             ],
                                                         ),
-                                                        Token("BINARY_BOOL_OPERATOR", "and"),
+                                                        Token("AND", "and"),
                                                         Tree(
                                                             "binary_comparison_operation",
                                                             [

--- a/tests/snapshots/join_operation/200_join_with_on.snapshot
+++ b/tests/snapshots/join_operation/200_join_with_on.snapshot
@@ -38,7 +38,7 @@ Tree(
                                     [
                                         Token("ON", "on"),
                                         Tree(
-                                            "indented_expression",
+                                            "indented_bool_expression",
                                             [
                                                 Tree(
                                                     "binary_bool_operation",
@@ -51,7 +51,7 @@ Tree(
                                                                 Token("CNAME", "field_b"),
                                                             ],
                                                         ),
-                                                        Token("BINARY_BOOL_OPERATOR", "and"),
+                                                        Token("AND", "and"),
                                                         Tree(
                                                             "binary_comparison_operation",
                                                             [

--- a/tests/snapshots/join_operation/300_multiple_joins.snapshot
+++ b/tests/snapshots/join_operation/300_multiple_joins.snapshot
@@ -65,7 +65,7 @@ Tree(
                                             [
                                                 Token("ON", "on"),
                                                 Tree(
-                                                    "indented_expression",
+                                                    "indented_bool_expression",
                                                     [
                                                         Tree(
                                                             "binary_comparison_operation",

--- a/tests/snapshots/join_operation/310_multiple_joins_nested.snapshot
+++ b/tests/snapshots/join_operation/310_multiple_joins_nested.snapshot
@@ -86,7 +86,7 @@ Tree(
                                                             [
                                                                 Token("ON", "on"),
                                                                 Tree(
-                                                                    "indented_expression",
+                                                                    "indented_bool_expression",
                                                                     [
                                                                         Tree(
                                                                             "binary_comparison_operation",

--- a/tests/snapshots/where_clause/000_single_expression.snapshot
+++ b/tests/snapshots/where_clause/000_single_expression.snapshot
@@ -25,7 +25,7 @@ Tree(
                     [
                         Tree("simple_table_name", [Token("CNAME", "table")]),
                         Token("WHERE", "where"),
-                        Tree("indented_expression", [Token("CNAME", "a")]),
+                        Tree("indented_bool_expression", [Token("CNAME", "a")]),
                     ],
                 ),
             ],

--- a/tests/snapshots/where_clause/100_leading_unary_bool_operator.snapshot
+++ b/tests/snapshots/where_clause/100_leading_unary_bool_operator.snapshot
@@ -26,7 +26,7 @@ Tree(
                         Tree("simple_table_name", [Token("CNAME", "table")]),
                         Token("WHERE", "where"),
                         Tree(
-                            "indented_expression",
+                            "indented_bool_expression",
                             [
                                 Tree(
                                     "leading_unary_bool_operation",

--- a/tests/snapshots/where_clause/110_trailing_unary_bool_operator.snapshot
+++ b/tests/snapshots/where_clause/110_trailing_unary_bool_operator.snapshot
@@ -26,7 +26,7 @@ Tree(
                         Tree("simple_table_name", [Token("CNAME", "table")]),
                         Token("WHERE", "where"),
                         Tree(
-                            "indented_expression",
+                            "indented_bool_expression",
                             [
                                 Tree(
                                     "trailing_unary_bool_operation",

--- a/tests/snapshots/where_clause/200_binary_bool_expression.snapshot
+++ b/tests/snapshots/where_clause/200_binary_bool_expression.snapshot
@@ -27,11 +27,11 @@ Tree(
                         Tree("simple_table_name", [Token("CNAME", "table")]),
                         Token("WHERE", "where"),
                         Tree(
-                            "indented_expression",
+                            "indented_bool_expression",
                             [
                                 Tree(
                                     "binary_bool_operation",
-                                    [Token("CNAME", "a"), Token("BINARY_BOOL_OPERATOR", "AND"), Token("CNAME", "b")],
+                                    [Token("CNAME", "a"), Token("AND", "AND"), Token("CNAME", "b")],
                                 )
                             ],
                         ),

--- a/tests/snapshots/where_clause/210_multiple_binary_bool_expression.snapshot
+++ b/tests/snapshots/where_clause/210_multiple_binary_bool_expression.snapshot
@@ -28,20 +28,16 @@ Tree(
                         Tree("simple_table_name", [Token("CNAME", "table")]),
                         Token("WHERE", "where"),
                         Tree(
-                            "indented_expression",
+                            "indented_bool_expression",
                             [
                                 Tree(
                                     "binary_bool_operation",
                                     [
                                         Token("CNAME", "a"),
-                                        Token("BINARY_BOOL_OPERATOR", "or"),
+                                        Token("OR", "or"),
                                         Tree(
                                             "binary_bool_operation",
-                                            [
-                                                Token("CNAME", "b"),
-                                                Token("BINARY_BOOL_OPERATOR", "and"),
-                                                Token("CNAME", "c"),
-                                            ],
+                                            [Token("CNAME", "b"), Token("AND", "and"), Token("CNAME", "c")],
                                         ),
                                     ],
                                 )

--- a/tests/snapshots/where_clause/300_where_macros.snapshot
+++ b/tests/snapshots/where_clause/300_where_macros.snapshot
@@ -28,20 +28,16 @@ Tree(
                         Tree("simple_table_name", [Token("CNAME", "table")]),
                         Token("WHERE", "where"),
                         Tree(
-                            "indented_expression",
+                            "indented_bool_expression",
                             [
                                 Tree(
                                     "binary_bool_operation",
                                     [
                                         Token("MACRO", "{{ macro_1('arg1', 'arg2')}}"),
-                                        Token("BINARY_BOOL_OPERATOR", "or"),
+                                        Token("OR", "or"),
                                         Tree(
                                             "binary_bool_operation",
-                                            [
-                                                Token("CNAME", "b"),
-                                                Token("BINARY_BOOL_OPERATOR", "and"),
-                                                Token("CNAME", "c"),
-                                            ],
+                                            [Token("CNAME", "b"), Token("AND", "and"), Token("CNAME", "c")],
                                         ),
                                     ],
                                 )

--- a/tests/snapshots/where_clause/400_comparison_operators.snapshot
+++ b/tests/snapshots/where_clause/400_comparison_operators.snapshot
@@ -16,6 +16,8 @@ where
   and i not like "%foo%"
   and j in (1, 2, 3)
   and k not in ("a", "b", "c")
+  and el between 1 and 2
+  and m not between "2020-01-01" and "2022-02-22"
 
 ---
 
@@ -37,6 +39,8 @@ WHERE
   AND i NOT LIKE "%foo%"
   AND j IN (1, 2, 3)
   AND k NOT IN ("a", "b", "c")
+  AND el BETWEEN 1 AND 2
+  AND m NOT BETWEEN "2020-01-01" AND "2022-02-22"
 
 ---
 
@@ -55,7 +59,7 @@ Tree(
                         Tree("simple_table_name", [Token("CNAME", "table")]),
                         Token("WHERE", "where"),
                         Tree(
-                            "indented_expression",
+                            "indented_bool_expression",
                             [
                                 Tree(
                                     "binary_bool_operation",
@@ -68,7 +72,7 @@ Tree(
                                                 Token("DOUBLE_QUOTED_STRING", '"b"'),
                                             ],
                                         ),
-                                        Token("BINARY_BOOL_OPERATOR", "and"),
+                                        Token("AND", "and"),
                                         Tree(
                                             "binary_bool_operation",
                                             [
@@ -80,7 +84,7 @@ Tree(
                                                         Token("SIGNED_NUMBER", "1"),
                                                     ],
                                                 ),
-                                                Token("BINARY_BOOL_OPERATOR", "and"),
+                                                Token("AND", "and"),
                                                 Tree(
                                                     "binary_bool_operation",
                                                     [
@@ -92,17 +96,17 @@ Tree(
                                                                 Token("CNAME", "d"),
                                                             ],
                                                         ),
-                                                        Token("BINARY_BOOL_OPERATOR", "and"),
+                                                        Token("AND", "and"),
                                                         Tree(
                                                             "binary_bool_operation",
                                                             [
                                                                 Token("CNAME", "a"),
-                                                                Token("BINARY_BOOL_OPERATOR", "and"),
+                                                                Token("AND", "and"),
                                                                 Tree(
                                                                     "binary_bool_operation",
                                                                     [
                                                                         Tree(
-                                                                            "parenthetical_expression",
+                                                                            "parenthetical_bool_expression",
                                                                             [
                                                                                 Token("LPAR", "("),
                                                                                 Tree(
@@ -119,16 +123,14 @@ Tree(
                                                                                                 Token("CNAME", "f"),
                                                                                             ],
                                                                                         ),
-                                                                                        Token(
-                                                                                            "BINARY_BOOL_OPERATOR", "or"
-                                                                                        ),
+                                                                                        Token("OR", "or"),
                                                                                         Token("CNAME", "g"),
                                                                                     ],
                                                                                 ),
                                                                                 Token("RPAR", ")"),
                                                                             ],
                                                                         ),
-                                                                        Token("BINARY_BOOL_OPERATOR", "and"),
+                                                                        Token("AND", "and"),
                                                                         Tree(
                                                                             "binary_bool_operation",
                                                                             [
@@ -143,7 +145,7 @@ Tree(
                                                                                         Token("CNAME", "e"),
                                                                                     ],
                                                                                 ),
-                                                                                Token("BINARY_BOOL_OPERATOR", "and"),
+                                                                                Token("AND", "and"),
                                                                                 Tree(
                                                                                     "binary_bool_operation",
                                                                                     [
@@ -158,10 +160,7 @@ Tree(
                                                                                                 Token("CNAME", "f"),
                                                                                             ],
                                                                                         ),
-                                                                                        Token(
-                                                                                            "BINARY_BOOL_OPERATOR",
-                                                                                            "and",
-                                                                                        ),
+                                                                                        Token("AND", "and"),
                                                                                         Tree(
                                                                                             "binary_bool_operation",
                                                                                             [
@@ -180,10 +179,7 @@ Tree(
                                                                                                         ),
                                                                                                     ],
                                                                                                 ),
-                                                                                                Token(
-                                                                                                    "BINARY_BOOL_OPERATOR",
-                                                                                                    "and",
-                                                                                                ),
+                                                                                                Token("AND", "and"),
                                                                                                 Tree(
                                                                                                     "binary_bool_operation",
                                                                                                     [
@@ -205,8 +201,7 @@ Tree(
                                                                                                             ],
                                                                                                         ),
                                                                                                         Token(
-                                                                                                            "BINARY_BOOL_OPERATOR",
-                                                                                                            "and",
+                                                                                                            "AND", "and"
                                                                                                         ),
                                                                                                         Tree(
                                                                                                             "binary_bool_operation",
@@ -229,7 +224,7 @@ Tree(
                                                                                                                     ],
                                                                                                                 ),
                                                                                                                 Token(
-                                                                                                                    "BINARY_BOOL_OPERATOR",
+                                                                                                                    "AND",
                                                                                                                     "and",
                                                                                                                 ),
                                                                                                                 Tree(
@@ -257,7 +252,7 @@ Tree(
                                                                                                                             ],
                                                                                                                         ),
                                                                                                                         Token(
-                                                                                                                            "BINARY_BOOL_OPERATOR",
+                                                                                                                            "AND",
                                                                                                                             "and",
                                                                                                                         ),
                                                                                                                         Tree(
@@ -294,38 +289,110 @@ Tree(
                                                                                                                                     ],
                                                                                                                                 ),
                                                                                                                                 Token(
-                                                                                                                                    "BINARY_BOOL_OPERATOR",
+                                                                                                                                    "AND",
                                                                                                                                     "and",
                                                                                                                                 ),
                                                                                                                                 Tree(
-                                                                                                                                    "in_comparison_operation",
+                                                                                                                                    "binary_bool_operation",
                                                                                                                                     [
-                                                                                                                                        Token(
-                                                                                                                                            "CNAME",
-                                                                                                                                            "k",
-                                                                                                                                        ),
-                                                                                                                                        Token(
-                                                                                                                                            "NOT",
-                                                                                                                                            "not",
-                                                                                                                                        ),
-                                                                                                                                        Token(
-                                                                                                                                            "IN",
-                                                                                                                                            "in",
-                                                                                                                                        ),
                                                                                                                                         Tree(
-                                                                                                                                            "in_list",
+                                                                                                                                            "in_comparison_operation",
                                                                                                                                             [
                                                                                                                                                 Token(
-                                                                                                                                                    "DOUBLE_QUOTED_STRING",
-                                                                                                                                                    '"a"',
+                                                                                                                                                    "CNAME",
+                                                                                                                                                    "k",
                                                                                                                                                 ),
                                                                                                                                                 Token(
-                                                                                                                                                    "DOUBLE_QUOTED_STRING",
-                                                                                                                                                    '"b"',
+                                                                                                                                                    "NOT",
+                                                                                                                                                    "not",
                                                                                                                                                 ),
                                                                                                                                                 Token(
-                                                                                                                                                    "DOUBLE_QUOTED_STRING",
-                                                                                                                                                    '"c"',
+                                                                                                                                                    "IN",
+                                                                                                                                                    "in",
+                                                                                                                                                ),
+                                                                                                                                                Tree(
+                                                                                                                                                    "in_list",
+                                                                                                                                                    [
+                                                                                                                                                        Token(
+                                                                                                                                                            "DOUBLE_QUOTED_STRING",
+                                                                                                                                                            '"a"',
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "DOUBLE_QUOTED_STRING",
+                                                                                                                                                            '"b"',
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "DOUBLE_QUOTED_STRING",
+                                                                                                                                                            '"c"',
+                                                                                                                                                        ),
+                                                                                                                                                    ],
+                                                                                                                                                ),
+                                                                                                                                            ],
+                                                                                                                                        ),
+                                                                                                                                        Token(
+                                                                                                                                            "AND",
+                                                                                                                                            "and",
+                                                                                                                                        ),
+                                                                                                                                        Tree(
+                                                                                                                                            "binary_bool_operation",
+                                                                                                                                            [
+                                                                                                                                                Tree(
+                                                                                                                                                    "between_comparison_operation",
+                                                                                                                                                    [
+                                                                                                                                                        Token(
+                                                                                                                                                            "CNAME",
+                                                                                                                                                            "el",
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "BETWEEN",
+                                                                                                                                                            "between",
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "SIGNED_NUMBER",
+                                                                                                                                                            "1",
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "AND",
+                                                                                                                                                            "and",
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "SIGNED_NUMBER",
+                                                                                                                                                            "2",
+                                                                                                                                                        ),
+                                                                                                                                                    ],
+                                                                                                                                                ),
+                                                                                                                                                Token(
+                                                                                                                                                    "AND",
+                                                                                                                                                    "and",
+                                                                                                                                                ),
+                                                                                                                                                Tree(
+                                                                                                                                                    "between_comparison_operation",
+                                                                                                                                                    [
+                                                                                                                                                        Token(
+                                                                                                                                                            "CNAME",
+                                                                                                                                                            "m",
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "NOT",
+                                                                                                                                                            "not",
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "BETWEEN",
+                                                                                                                                                            "between",
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "DOUBLE_QUOTED_STRING",
+                                                                                                                                                            '"2020-01-01"',
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "AND",
+                                                                                                                                                            "and",
+                                                                                                                                                        ),
+                                                                                                                                                        Token(
+                                                                                                                                                            "DOUBLE_QUOTED_STRING",
+                                                                                                                                                            '"2022-02-22"',
+                                                                                                                                                        ),
+                                                                                                                                                    ],
                                                                                                                                                 ),
                                                                                                                                             ],
                                                                                                                                         ),


### PR DESCRIPTION
* Neaten expression.lark
* Change binary_bool_operation to two-branched rule instead of using
  two-branched token
* shift case to base_expression
* indented_expression --> indented_bool_expression
* expression --> bool_expression, with references to bool_expression or base_expression
* also parenthesized_expression to parenthesized_bool_expression
* add between_comparison_operation