### PR TITLE
Github Action Caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,31 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        sudo apt-get -y install make
-        pip install poetry==1.1.12
-        poetry install
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v2
+      with:
+        path: .venv
+        # Cache the complete venv dir for a given python version and poetry.lock
+        key: venv-python-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+
+    - name: Install Project
+      shell: bash
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install
+
     - name: Run all tests and linting
       run: |
         make test


### PR DESCRIPTION
* Use github action caching, loosely following https://blog.zenml.io/github-actions-in-action/
* no longer installs make