### PR TITLE
Reserved word fix

### DIFF
--- a/sqlean/grammar/reserved_words.lark
+++ b/sqlean/grammar/reserved_words.lark
@@ -1,37 +1,37 @@
 // BigQuery data types, mainly for casting to
-!data_type: "BOOL"i
-    | "BYTES"i ["(" INT ")"]
-    | "DATE"i
-    | "DATETIME"i
-    | "TIMESTAMP"i
-    | "INT64"i
-    | "INT"i
-    | "SMALLINT"i
-    | "INTEGER"i
-    | "BIGINT"i
-    | "TINYINT"i
-    | "BYTEINT"i
-    | "NUMERIC"i
-    | "DECIMAL"i
-    | "BIGNUMERIC"i
-    | "BIGDECIMAL"i
-    | "FLOAT64"i
-    | "STRING"i
+!data_type: /\bBOOL\b/i
+    | /\bBYTES\b/i ["(" INT ")"]
+    | /\bDATE\b/i
+    | /\bDATETIME\b/i
+    | /\bTIMESTAMP\b/i
+    | /\bINT64\b/i
+    | /\bINT\b/i
+    | /\bSMALLINT\b/i
+    | /\bINTEGER\b/i
+    | /\bBIGINT\b/i
+    | /\bTINYINT\b/i
+    | /\bBYTEINT\b/i
+    | /\bNUMERIC\b/i
+    | /\bDECIMAL\b/i
+    | /\bBIGNUMERIC\b/i
+    | /\bBIGDECIMAL\b/i
+    | /\bFLOAT64\b/i
+    | /\bSTRING\b/i
 
 // BigQuery date/time intervals
 ?interval: DATE_INTERVAL
     | TIME_INTERVAL
-DATE_INTERVAL.2: "DAY"i
-    | "DAYOFYEAR"i
-    | "MONTH"i
-    | "WEEK"i
-    | "ISOWEEK"i
-    | "YEAR"i
-    | "ISOYEAR"i
-TIME_INTERVAL.2: "MICROSECOND"i
-    | "MILLISECOND"i
-    | "SECOND"i
-    | "MINUTE"i
-    | "HOUR"i
+DATE_INTERVAL.2: /\bDAY\b/i
+    | /\bDAYOFYEAR\b/i
+    | /\bMONTH\b/i
+    | /\bWEEK\b/i
+    | /\bISOWEEK\b/i
+    | /\bYEAR\b/i
+    | /\bISOYEAR\b/i
+TIME_INTERVAL.2: /\bMICROSECOND\b/i
+    | /\bMILLISECOND\b/i
+    | /\bSECOND\b/i
+    | /\bMINUTE\b/i
+    | /\bHOUR\b/i
 
 %import common.INT

--- a/tests/snapshots/function/041_arg_item_mistaken_interval.snapshot
+++ b/tests/snapshots/function/041_arg_item_mistaken_interval.snapshot
@@ -1,0 +1,44 @@
+select
+    max(days_before) -- if not treated properly, day is considered as a DATE_INTERVAL
+from a
+
+---
+
+SELECT
+  MAX(days_before),  -- if not treated properly, day is considered as a DATE_INTERVAL
+FROM
+  a
+
+---
+
+Tree(
+    "query_file",
+    [
+        Tree(
+            "select_expr",
+            [
+                Tree("select_type", [Token("SELECT", "select")]),
+                Tree(
+                    "select_list",
+                    [
+                        Tree(
+                            "select_item_unaliased",
+                            [
+                                Tree(
+                                    "standard_function_expression",
+                                    [
+                                        Tree("function_name", [Token("CNAME", "max")]),
+                                        Tree("arg_list", [Tree("arg_item", [Token("CNAME", "days_before")])]),
+                                    ],
+                                )
+                            ],
+                        ),
+                        Token("INLINE_COMMENT", "-- if not treated properly, day is considered as a DATE_INTERVAL"),
+                    ],
+                ),
+                Token("FROM", "from"),
+                Tree("from_clause", [Tree("simple_table_name", [Token("CNAME", "a")])]),
+            ],
+        )
+    ],
+)

--- a/tests/snapshots/function/100_cast_arguments.snapshot
+++ b/tests/snapshots/function/100_cast_arguments.snapshot
@@ -52,7 +52,7 @@ Tree(
                                                     [
                                                         Token("CNAME", "a"),
                                                         Token("AS", "as"),
-                                                        Tree("data_type", [Token("ANON_0", "int")]),
+                                                        Tree("data_type", [Token("ANON_6", "int")]),
                                                     ],
                                                 )
                                             ],
@@ -77,7 +77,7 @@ Tree(
                                                     [
                                                         Token("CNAME", "b"),
                                                         Token("AS", "as"),
-                                                        Tree("data_type", [Token("INT64", "int64")]),
+                                                        Tree("data_type", [Token("ANON_5", "int64")]),
                                                     ],
                                                 )
                                             ],
@@ -102,7 +102,7 @@ Tree(
                                                     [
                                                         Token("CNAME", "c"),
                                                         Token("AS", "as"),
-                                                        Tree("data_type", [Token("STRING", "string")]),
+                                                        Tree("data_type", [Token("ANON_17", "string")]),
                                                     ],
                                                 )
                                             ],
@@ -126,7 +126,7 @@ Tree(
                                                     [
                                                         Token("CNAME", "d"),
                                                         Token("AS", "as"),
-                                                        Tree("data_type", [Token("NUMERIC", "numeric")]),
+                                                        Tree("data_type", [Token("ANON_12", "numeric")]),
                                                     ],
                                                 )
                                             ],
@@ -150,7 +150,7 @@ Tree(
                                                     [
                                                         Token("CNAME", "e"),
                                                         Token("AS", "as"),
-                                                        Tree("data_type", [Token("BYTES", "bytes")]),
+                                                        Tree("data_type", [Token("ANON_1", "bytes")]),
                                                     ],
                                                 )
                                             ],
@@ -177,7 +177,7 @@ Tree(
                                                         Tree(
                                                             "data_type",
                                                             [
-                                                                Token("BYTES", "bytes"),
+                                                                Token("ANON_1", "bytes"),
                                                                 Token("LPAR", "("),
                                                                 Token("INT", "3"),
                                                                 Token("RPAR", ")"),
@@ -206,7 +206,7 @@ Tree(
                                                     [
                                                         Token("CNAME", "g"),
                                                         Token("AS", "as"),
-                                                        Tree("data_type", [Token("DECIMAL", "decimal")]),
+                                                        Tree("data_type", [Token("ANON_13", "decimal")]),
                                                     ],
                                                 )
                                             ],
@@ -230,7 +230,7 @@ Tree(
                                                     [
                                                         Token("CNAME", "h"),
                                                         Token("AS", "as"),
-                                                        Tree("data_type", [Token("FLOAT64", "float64")]),
+                                                        Tree("data_type", [Token("ANON_16", "float64")]),
                                                     ],
                                                 )
                                             ],
@@ -254,7 +254,7 @@ Tree(
                                                     [
                                                         Token("CNAME", "i"),
                                                         Token("AS", "as"),
-                                                        Tree("data_type", [Token("TIMESTAMP", "timestamp")]),
+                                                        Tree("data_type", [Token("ANON_4", "timestamp")]),
                                                     ],
                                                 )
                                             ],

--- a/tests/snapshots/function/200_nonstandard_function_names.snapshot
+++ b/tests/snapshots/function/200_nonstandard_function_names.snapshot
@@ -85,7 +85,7 @@ Tree(
                                             [
                                                 Token("BACKQUOTE", "`"),
                                                 Token("PROJECT_ID", "project_id"),
-                                                Token("ANON_3", "`."),
+                                                Token("ANON_20", "`."),
                                                 Token("CNAME", "dataset_id"),
                                                 Token("DOT", "."),
                                                 Token("CNAME", "function"),

--- a/tests/snapshots/select_item/410_select_tablestar.snapshot
+++ b/tests/snapshots/select_item/410_select_tablestar.snapshot
@@ -24,7 +24,7 @@ Tree(
                     [
                         Tree(
                             "select_item_unaliased",
-                            [Tree("star_expression", [Token("CNAME", "table_2"), Token("ANON_2", ".*")])],
+                            [Tree("star_expression", [Token("CNAME", "table_2"), Token("ANON_19", ".*")])],
                         )
                     ],
                 ),


### PR DESCRIPTION
* if a variable starting with `day` was used as an argument, this was
  being interpreted as a `DATE_INTERVAL`
* fix was to use regex to match whole words