### PR TITLE
Better comments 2

### DIFF
--- a/sqlean/grammar/expression.lark
+++ b/sqlean/grammar/expression.lark
@@ -1,7 +1,7 @@
 ////////////
 // select //
 ////////////
-select_list: select_item ("," COMMENT* select_item)* [","] COMMENT*
+select_list: COMMENT* select_item (COMMENT* "," COMMENT* select_item)* [","] COMMENT*
 ?select_item: select_item_unaliased
     | select_item_aliased
 select_item_aliased: base_expression as_alias
@@ -85,7 +85,7 @@ indented_bool_expression: bool_expression
     | unary_bool_operation
     | base_expression
 
-binary_bool_operation: bool_expression AND bool_expression
+binary_bool_operation: bool_expression COMMENT* AND COMMENT* bool_expression COMMENT*
     | bool_expression OR bool_expression
 AND: "AND"i
 OR: "OR"i

--- a/sqlean/grammar/sql.lark
+++ b/sqlean/grammar/sql.lark
@@ -29,7 +29,7 @@ FROM: "FROM"i
 //////////
 !from_clause: from_item ["WHERE"i indented_bool_expression] [groupby_modifier] [orderby_modifier]
 !?from_item: join_operation
-    | table_item
+    | table_item COMMENT*
     | sub_query_expr
 
 !sub_query_expr: "(" query_expr ")"

--- a/sqlean/sql_styler.py
+++ b/sqlean/sql_styler.py
@@ -70,7 +70,7 @@ class CommentedListClass:  # pylint: disable=too-many-instance-attributes
         return "".join(self.output)
 
     def _fill_output(self) -> None:
-        self.output.append(str(self.children[0]))
+        self.output.append(self._indent_if_comment(self.children[0]))
         for idx in range(1, self.num_children):
             self._append_child_by_idx(idx)
         self.output[-1] += self._get_separator_by_idx(self.num_children - 1, True)
@@ -401,6 +401,16 @@ class FromMixin(BaseMixin):
         output = f"{str(node.children[0]).lstrip()} AS {node.children[1]}"
         return self._apply_indent(output, node.data.indent_level)
 
+    def from_item(self, node: CTree) -> str:
+        """print from_item"""
+        return self._rollup_list(
+            children=list(node.children),
+            separator="",
+            line_separator=linesep,
+            has_ending_separator=False,
+            item_types=set(),
+        )
+
 
 @v_args(tree=True)
 class JoinMixin(BaseMixin):
@@ -575,7 +585,15 @@ class ExpressionMixin(BaseMixin):
     @staticmethod
     def binary_bool_operation(node: CTree) -> str:
         """print binary_bool_operation"""
-        return f"{node.children[0]}\n{node.children[1]} {node.children[2]}"
+        list_ = CommentedListClass(
+            children=list(node.children),
+            separator="",
+            line_separator=linesep,
+            has_ending_separator=False,
+            indent="",
+        )
+        output = list_.rollup_list()
+        return output.replace("AND" + linesep, "AND ").replace("OR" + linesep, "OR ")
 
     @staticmethod
     def parenthetical_bool_expression(node: CTree) -> str:

--- a/tests/snapshots/comment/000_select_item_comment.snapshot
+++ b/tests/snapshots/comment/000_select_item_comment.snapshot
@@ -18,14 +18,6 @@ cte_2 AS (
  -- comment after a block comment
 	    c
     from table_2
-),
-
-cte_3 AS (
-    select
-	    a, --another comment on a
-	    b,
-	    c --another comment on c
-    from table_3
 )
 
 SELECT
@@ -56,15 +48,6 @@ cte_2 AS (
     c,
   FROM
     table_2
-),
-
-cte_3 AS (
-  SELECT
-    a,  -- another comment on a
-    b,
-    c,  -- another comment on c
-  FROM
-    table_3
 )
 
 SELECT
@@ -125,40 +108,13 @@ Tree(
                                         Tree("select_item_unaliased", [Token("CNAME", "a")]),
                                         Tree("select_item_unaliased", [Token("CNAME", "b")]),
                                         Token("COMMENT", "--another comment on b"),
-                                        Token("COMMENT", "/* block\n        comment */"),
+                                        Token("COMMENT", "/* block\n     comment */"),
                                         Token("COMMENT", "-- comment after a block comment"),
                                         Tree("select_item_unaliased", [Token("CNAME", "c")]),
                                     ],
                                 ),
                                 Token("FROM", "from"),
                                 Tree("from_clause", [Token("STANDARD_TABLE_NAME", "table_2")]),
-                            ],
-                        ),
-                        Token("RPAR", ")"),
-                    ],
-                ),
-                Tree(
-                    "with_clause",
-                    [
-                        Token("CNAME", "cte_3"),
-                        Token("AS", "AS"),
-                        Token("LPAR", "("),
-                        Tree(
-                            "select_expr",
-                            [
-                                Tree("select_type", [Token("SELECT", "select")]),
-                                Tree(
-                                    "select_list",
-                                    [
-                                        Tree("select_item_unaliased", [Token("CNAME", "a")]),
-                                        Token("COMMENT", "--another comment on a"),
-                                        Tree("select_item_unaliased", [Token("CNAME", "b")]),
-                                        Tree("select_item_unaliased", [Token("CNAME", "c")]),
-                                        Token("COMMENT", "--another comment on c"),
-                                    ],
-                                ),
-                                Token("FROM", "from"),
-                                Tree("from_clause", [Token("STANDARD_TABLE_NAME", "table_3")]),
                             ],
                         ),
                         Token("RPAR", ")"),

--- a/tests/snapshots/comment/010_select_item_comment_before_comma.snapshot
+++ b/tests/snapshots/comment/010_select_item_comment_before_comma.snapshot
@@ -1,0 +1,48 @@
+select
+    a --comment before a comma
+    , b --another comment before a comma
+    , c --trailing comment
+    /*block
+    comment
+    */
+from table
+
+---
+
+SELECT
+  a,  -- comment before a comma
+  b,  -- another comment before a comma
+  c,  -- trailing comment
+  /* block
+     comment
+  */
+FROM
+  table
+
+---
+
+Tree(
+    "query_file",
+    [
+        Tree(
+            "select_expr",
+            [
+                Tree("select_type", [Token("SELECT", "select")]),
+                Tree(
+                    "select_list",
+                    [
+                        Tree("select_item_unaliased", [Token("CNAME", "a")]),
+                        Token("COMMENT", "--comment before a comma"),
+                        Tree("select_item_unaliased", [Token("CNAME", "b")]),
+                        Token("COMMENT", "--another comment before a comma"),
+                        Tree("select_item_unaliased", [Token("CNAME", "c")]),
+                        Token("COMMENT", "--trailing comment"),
+                        Token("COMMENT", "/*block\n    comment\n    */"),
+                    ],
+                ),
+                Token("FROM", "from"),
+                Tree("from_clause", [Token("STANDARD_TABLE_NAME", "table")]),
+            ],
+        )
+    ],
+)

--- a/tests/snapshots/comment/020_select_item_comment_first.snapshot
+++ b/tests/snapshots/comment/020_select_item_comment_first.snapshot
@@ -1,0 +1,42 @@
+select
+    /* comment before any item */
+    a,
+    b,
+    c --trailing comment
+from table
+
+---
+
+SELECT
+  /* comment before any item */
+  a,
+  b,
+  c,  -- trailing comment
+FROM
+  table
+
+---
+
+Tree(
+    "query_file",
+    [
+        Tree(
+            "select_expr",
+            [
+                Tree("select_type", [Token("SELECT", "select")]),
+                Tree(
+                    "select_list",
+                    [
+                        Token("COMMENT", "/* comment before any item */"),
+                        Tree("select_item_unaliased", [Token("CNAME", "a")]),
+                        Tree("select_item_unaliased", [Token("CNAME", "b")]),
+                        Tree("select_item_unaliased", [Token("CNAME", "c")]),
+                        Token("COMMENT", "--trailing comment"),
+                    ],
+                ),
+                Token("FROM", "from"),
+                Tree("from_clause", [Token("STANDARD_TABLE_NAME", "table")]),
+            ],
+        )
+    ],
+)

--- a/tests/snapshots/comment/400_where_comments.snapshot
+++ b/tests/snapshots/comment/400_where_comments.snapshot
@@ -1,0 +1,94 @@
+select
+  *
+from
+  table
+where
+  a > b
+  -- and b < c
+
+  /* mark a new section */
+  and /* test */ c < d -- about c
+  and d < e -- about e
+
+---
+
+SELECT
+  *,
+FROM
+  table
+WHERE
+  a > b
+  -- and b < c
+  
+  /* mark a new section */
+  AND  /* test */  c < d  -- about c
+  AND d < e  -- about e
+
+---
+
+Tree(
+    "query_file",
+    [
+        Tree(
+            "select_expr",
+            [
+                Tree("select_type", [Token("SELECT", "select")]),
+                Tree("select_list", [Tree("select_item_unaliased", [Tree("star_expression", [Token("STAR", "*")])])]),
+                Token("FROM", "from"),
+                Tree(
+                    "from_clause",
+                    [
+                        Token("STANDARD_TABLE_NAME", "table"),
+                        Token("WHERE", "where"),
+                        Tree(
+                            "indented_bool_expression",
+                            [
+                                Tree(
+                                    "binary_bool_operation",
+                                    [
+                                        Tree(
+                                            "binary_comparison_operation",
+                                            [
+                                                Token("CNAME", "a"),
+                                                Token("BINARY_COMPARISON_OPERATOR", ">"),
+                                                Token("CNAME", "b"),
+                                            ],
+                                        ),
+                                        Token("COMMENT", "-- and b < c"),
+                                        Token("COMMENT", "/* mark a new section */"),
+                                        Token("AND", "and"),
+                                        Token("COMMENT", "/* test */"),
+                                        Tree(
+                                            "binary_bool_operation",
+                                            [
+                                                Tree(
+                                                    "binary_comparison_operation",
+                                                    [
+                                                        Token("CNAME", "c"),
+                                                        Token("BINARY_COMPARISON_OPERATOR", "<"),
+                                                        Token("CNAME", "d"),
+                                                    ],
+                                                ),
+                                                Token("COMMENT", "-- about c"),
+                                                Token("AND", "and"),
+                                                Tree(
+                                                    "binary_comparison_operation",
+                                                    [
+                                                        Token("CNAME", "d"),
+                                                        Token("BINARY_COMPARISON_OPERATOR", "<"),
+                                                        Token("CNAME", "e"),
+                                                    ],
+                                                ),
+                                                Token("COMMENT", "-- about e"),
+                                            ],
+                                        ),
+                                    ],
+                                )
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+    ],
+)

--- a/tests/snapshots/comment/500_table_comments.snapshot
+++ b/tests/snapshots/comment/500_table_comments.snapshot
@@ -1,0 +1,60 @@
+select
+  *
+from
+  table -- this is an inline comment
+  /* table_2 */
+where
+  a > b
+
+---
+
+SELECT
+  *,
+FROM
+  table  -- this is an inline comment
+  /* table_2 */
+WHERE
+  a > b
+
+---
+
+Tree(
+    "query_file",
+    [
+        Tree(
+            "select_expr",
+            [
+                Tree("select_type", [Token("SELECT", "select")]),
+                Tree("select_list", [Tree("select_item_unaliased", [Tree("star_expression", [Token("STAR", "*")])])]),
+                Token("FROM", "from"),
+                Tree(
+                    "from_clause",
+                    [
+                        Tree(
+                            "from_item",
+                            [
+                                Token("STANDARD_TABLE_NAME", "table"),
+                                Token("COMMENT", "-- this is an inline comment"),
+                                Token("COMMENT", "/* table_2 */"),
+                            ],
+                        ),
+                        Token("WHERE", "where"),
+                        Tree(
+                            "indented_bool_expression",
+                            [
+                                Tree(
+                                    "binary_comparison_operation",
+                                    [
+                                        Token("CNAME", "a"),
+                                        Token("BINARY_COMPARISON_OPERATOR", ">"),
+                                        Token("CNAME", "b"),
+                                    ],
+                                )
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+    ],
+)


### PR DESCRIPTION
* In select_list, allow comments
  * before the comma
  * before the first item
* Allow comments in where items (slightly hacky...)
* Allow comments in from clause (but not with joins)

This way of doing comments is not-scalable for the grammar. We'll need
to change the strategy down the road.